### PR TITLE
add simple Dockerfile and docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12 
+WORKDIR /app
+
+
+# install python dependencies
+
+COPY requirements.txt requirements.txt
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY lobby/ lobby/
+
+## add finalization arguments
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD curl -f -X GET http://localhost:1717/health
+
+EXPOSE 3001
+
+CMD [ "python3", "-m" , "flask", "--app=lobby.main", "run", "--host=0.0.0.0", "--port=1717"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ COPY lobby/ lobby/
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD curl -f -X GET http://localhost:1717/health
 
-EXPOSE 3001
+EXPOSE 1717
 
-CMD [ "python3", "-m" , "flask", "--app=lobby.main", "run", "--host=0.0.0.0", "--port=1717"]
+CMD [ "python3", "lobby/main.py", "prod"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,30 @@
 # The Lob(b)y Server Everybody Asked For!
 
 More to come here...
+
+
+## Deploy with docker compose
+
+You need a running docker service and docker compose installed
+
+
+Then build the image:
+
+```bash
+docker build -t obpf-lobby .
+```
+
+Now you can run the docker compose file.
+
+```bash
+docker compose up -d
+```
+Note: the port is 1717 to proxy it through something like nginx.
+
+
+Other common docker compose comands include:
+```bash
+docker compose down # stop all containers
+docker compose ps # get details about running containers
+docker compose logs -f # see the logs of all containers  (-f watches them)
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+name: "obpf-lobby"
+services:
+    flask:
+        container_name: obpf-lobby
+        image: obpf-lobby:latest
+        ports:
+            - "1717:1717"
+        volumes:
+            - "./files/:/app/files/"

--- a/lobby/main.py
+++ b/lobby/main.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 import time
 import typing
 from dataclasses import dataclass
@@ -205,4 +206,9 @@ def register() -> tuple[Response, HTTPStatus]:
 
 # this runs, when you launch this file manually, otherwise flask imports this file and ignores this
 if __name__ == "__main__":
-    app.run(debug=True)
+    print(sys.argv)
+    if len(sys.argv) >= 2 and sys.argv[1] == "prod":
+        from waitress import serve
+        serve(app, host="0.0.0.0", port=1717)
+    else:
+        app.run(debug=True)

--- a/lobby/main.py
+++ b/lobby/main.py
@@ -81,6 +81,11 @@ class PlayerInfo(JsonSchemaMixin):
         return cls(id_, user.username)
 
 
+@app.route("/health", methods=["GET"])
+def health_check():
+    return create_ok_response({})
+
+
 @app.route("/lobbies", methods=["GET"])
 def lobby_list():
     @dataclass
@@ -198,4 +203,6 @@ def register() -> tuple[Response, HTTPStatus]:
     return create_response(HTTPStatus.CREATED, {"id": new_user.id})
 
 
-app.run(debug=True)
+# this runs, when you launch this file manually, otherwise flask imports this file and ignores this
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,5 @@ setuptools==69.0.3
 six==1.16.0
 SQLAlchemy==2.0.25
 typing_extensions==4.9.0
+waitress==2.1.2
 Werkzeug==3.0.1


### PR DESCRIPTION
This adds a `Dockerfile` and `docker-compose.yml` file, the README describes how to use them

fix two flask errors:
```
#  * Ignoring a call to 'app.run()' that would block the current 'flask' CLI command.
#    Only call 'app.run()' in an 'if __name__ == "__main__"' guard.
``` 
fix it, by checking, if the file is called directly or by imported by flask

```WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.``` so I use the suggested package by [flask itself](https://flask.palletsprojects.com/en/3.0.x/deploying/)

