### PR TITLE
Add API version to API endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 attrs==23.2.0
 bcrypt==4.1.2
 blinker==1.7.0
+cffi==1.16.0
 click==8.1.7
 colorama==0.4.6
+cryptography==42.0.2
 dataclasses-jsonschema==2.16.0
 Flask==3.0.0
 Flask-Bcrypt==1.0.1
@@ -12,8 +14,10 @@ itsdangerous==2.1.2
 Jinja2==3.1.3
 jsonschema==4.21.0
 jsonschema-specifications==2023.12.1
+jwt==1.3.1
 MarkupSafe==2.1.3
 nodeenv==1.8.0
+pycparser==2.21
 pyright==1.1.347
 python-dateutil==2.8.2
 referencing==0.32.1


### PR DESCRIPTION
- fix `requirements.txt`, since `jwt` and sub-dependencies were missing

Suggestion for the API:
Since this API isn't stable yet, I suggest adding a version endpoint, so that clients, that implement communication with this API can refer to that.

We can go against SemVer and say, that every change to the version below "1.0.0" is a potential breaking change and then bump the version to "1.0.0" after the API is stable and then follow SemVer guidelines for stability.

This helps clients massively, if they have the ability to connect to different Servers, so that they can determine which api version the server has and if the client supports the server.

I implemented that, by adding a `/version` endpoint, that returns the version, which is set to "0.1.0" atm.
